### PR TITLE
install rule for orbbec_camera_node

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,7 +227,7 @@ add_orbbec_executable(list_camera_profile_mode_node src/list_camera_profile_mode
 add_orbbec_executable(orbbec_camera_node src/main.cpp)
 
 # Install
-install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_nodelet ${EXECUTABLES}
+install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_node ${PROJECT_NAME}_nodelet ${EXECUTABLES}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}


### PR DESCRIPTION
- add missing install rule for orbbec_camera_node

Related to:
- https://github.com/orbbec/OrbbecSDK_ROS1/issues/22